### PR TITLE
Send runId to sharkster when triggin gdaiily run.

### DIFF
--- a/src/db/dailyRunsEntity.ts
+++ b/src/db/dailyRunsEntity.ts
@@ -35,8 +35,6 @@ export async function postDailyRun(runId: string) {
   const data = {
     runId,
     timeInitiated: Date.now(),
-    timeEnded: Date.now(),
-    duration: 1000,
     status: DailyRunStatus.INITIATED,
   };
   await db.collection("daily-runs").doc(runId).set(data);

--- a/src/db/errorsEntity.ts
+++ b/src/db/errorsEntity.ts
@@ -1,0 +1,49 @@
+import { db } from "../services/firestoreService";
+import { ErrorDataParsedType } from "./errorsMeta";
+
+export async function getError(runId: string) {
+  const query = db.collection("error");
+  const results = await query.where("runId", "==", runId).get();
+  if (results.size === 0) {
+    return null;
+  }
+
+  const doc = results.docs[0];
+  const { message, timestamp, miscJson } = doc.data();
+  return {
+    message,
+    timestamp,
+    runId,
+    misc: JSON.parse(miscJson),
+  } as ErrorDataParsedType;
+}
+
+export async function getErrorsByDate(date: string) {
+  const result: ErrorDataParsedType[] = [];
+  const docs = await db
+    .collection("errors")
+    .where("runId", ">=", date)
+    .where("runId", "<", (parseInt(date) + 1).toString())
+    .get();
+  docs.forEach((doc: any) => {
+    const { message, runId, timestamp, miscJson } = doc.data();
+    result.push({
+      message,
+      timestamp,
+      runId,
+      misc: JSON.parse(miscJson),
+    });
+  });
+
+  return result;
+}
+
+export async function postError(runId: string, message: string, misc: any) {
+  const data = {
+    runId,
+    message: message,
+    timestamp: Date.now(),
+    miscJson: JSON.stringify(misc),
+  };
+  await db.collection("errors").doc(runId).set(data);
+}

--- a/src/db/errorsMeta.ts
+++ b/src/db/errorsMeta.ts
@@ -1,0 +1,6 @@
+export type ErrorDataParsedType = {
+  runId: string;
+  message: string;
+  misc: Record<string, any>;
+  timestamp: number;
+};

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -19,3 +19,15 @@ export const getDateTime = (timestamp: string) => {
     nowHours,
   )}:${addZero(nowMinutes)}`;
 };
+
+export const getNewRunId = () => {
+  const now = new Date();
+  const nowDate = now.getDate();
+  const nowMonth = now.getMonth() + 1;
+  const nowHours = now.getHours();
+  const nowMinutes = now.getMinutes();
+  const nowSeconds = now.getSeconds();
+  return `${now.getFullYear()}${addZero(nowMonth)}${addZero(nowDate)}_${addZero(
+    nowHours,
+  )}${addZero(nowMinutes)}${addZero(nowSeconds)}`;
+};

--- a/src/pages/api/sharkster/daily-run-error.ts
+++ b/src/pages/api/sharkster/daily-run-error.ts
@@ -1,0 +1,34 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { storeDailyRunError } from "../../../lib/dailyRunHandler";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const { method, body } = req;
+  try {
+    switch (method) {
+      case "POST":
+        const jsonBody = JSON.parse(body.json);
+        await storeDailyRunError(jsonBody);
+
+        break;
+      default:
+        throw new Error(`Unsupported method: ${method as string}`);
+    }
+
+    res.status(200).json({});
+  } catch (e) {
+    let message;
+    if (e instanceof Error) {
+      message = e.message;
+      if (typeof e.message !== "string") {
+        message = e;
+      }
+    }
+    console.error(message);
+    return res.status(500).json({
+      error: message,
+    });
+  }
+}

--- a/src/services/sharksterService.ts
+++ b/src/services/sharksterService.ts
@@ -14,8 +14,10 @@ export const getSessions = async () => {
   return convertResult(resp);
 };
 
-export const triggerDailyRun = async () => {
-  const resp = await fetch(`${SERVICE_SHARKSTER_API_BASE_URL}/breakouts`);
+export const triggerDailyRun = async (runId: string) => {
+  const resp = await fetch(
+    `${SERVICE_SHARKSTER_API_BASE_URL}/breakouts?runId=${runId}`,
+  );
 
   return convertResult(resp);
 };


### PR DESCRIPTION
Expose endpoint to collect reported errors from Sharskter, and store in errors collecion at Firestore.