### PR TITLE
Change enum name to prevent confusion

### DIFF
--- a/src/components/molecules/PlaceOrderButton.tsx
+++ b/src/components/molecules/PlaceOrderButton.tsx
@@ -71,7 +71,7 @@ const PlaceOrderButton = ({
           ticker,
           breakoutRef,
           status: TRADE_STATUS.READY,
-          type: TRADE_SIDE.BUY,
+          side: TRADE_SIDE.BUY,
         });
         void handleBuyOrder(ticker, entryPrice, quantity, breakoutRef);
         typeof onClick === "function" && onClick();

--- a/src/components/molecules/PlaceOrderButton.tsx
+++ b/src/components/molecules/PlaceOrderButton.tsx
@@ -6,7 +6,7 @@ import * as backendService from "../../services/backendService";
 import { useInterval } from "usehooks-ts";
 import { ONE_MINUTE_IN_MS } from "../../lib/helpers";
 import { useTradesStore } from "../../store/tradesStore";
-import { TRADE_STATUS, TRADE_TYPE } from "../../db/tradesMeta";
+import { TRADE_STATUS, TRADE_SIDE } from "../../db/tradesMeta";
 
 const StyledButton = styled(Button)`
   text-align: center;
@@ -71,7 +71,7 @@ const PlaceOrderButton = ({
           ticker,
           breakoutRef,
           status: TRADE_STATUS.READY,
-          type: TRADE_TYPE.BUY,
+          type: TRADE_SIDE.BUY,
         });
         void handleBuyOrder(ticker, entryPrice, quantity, breakoutRef);
         typeof onClick === "function" && onClick();
@@ -81,8 +81,8 @@ const PlaceOrderButton = ({
         {!trade
           ? "PLACE ORDER"
           : trade.status === TRADE_STATUS.READY
-            ? "ON ITS WAY TO THE MARKET"
-            : trade.status}
+          ? "ON ITS WAY TO THE MARKET"
+          : trade.status}
       </div>
       <div>${size}</div>
     </StyledButton>

--- a/src/db/tradesMeta.ts
+++ b/src/db/tradesMeta.ts
@@ -16,7 +16,7 @@ export enum TRADE_STATUS {
 
 export interface TradesDataType {
   ticker: string;
-  type: TRADE_SIDE;
+  side: TRADE_SIDE;
   status: TRADE_STATUS;
   price: number;
   quantity: number;

--- a/src/db/tradesMeta.ts
+++ b/src/db/tradesMeta.ts
@@ -1,5 +1,5 @@
 // These are also mapped all the way to lowercased and sent to alpacaca (as prop "side")
-export enum TRADE_TYPE {
+export enum TRADE_SIDE {
   BUY = "BUY",
   SELL = "SELL",
 }
@@ -16,7 +16,7 @@ export enum TRADE_STATUS {
 
 export interface TradesDataType {
   ticker: string;
-  type: TRADE_TYPE;
+  type: TRADE_SIDE;
   status: TRADE_STATUS;
   price: number;
   quantity: number;

--- a/src/lib/brokerHandler.ts
+++ b/src/lib/brokerHandler.ts
@@ -1,6 +1,6 @@
 import fetch, { BodyInit } from "node-fetch";
 import { Order } from "../components/organisms/OrdersList";
-import { TRADE_STATUS, TRADE_TYPE } from "../db/tradesMeta";
+import { TRADE_STATUS, TRADE_SIDE } from "../db/tradesMeta";
 import { convertResult } from "../util";
 
 export const handleBuyOrder = async (
@@ -11,7 +11,7 @@ export const handleBuyOrder = async (
 ) => {
   const body: BodyInit = JSON.stringify({
     ticker,
-    type: TRADE_TYPE.BUY,
+    type: TRADE_SIDE.BUY,
     status: TRADE_STATUS.READY,
     price,
     quantity,

--- a/src/lib/brokerHandler.ts
+++ b/src/lib/brokerHandler.ts
@@ -11,7 +11,7 @@ export const handleBuyOrder = async (
 ) => {
   const body: BodyInit = JSON.stringify({
     ticker,
-    type: TRADE_SIDE.BUY,
+    side: TRADE_SIDE.BUY,
     status: TRADE_STATUS.READY,
     price,
     quantity,

--- a/src/pages/api/broker/orders/index.ts
+++ b/src/pages/api/broker/orders/index.ts
@@ -33,14 +33,14 @@ export default async function handler(
         const body = JSON.parse(req.body);
         const {
           ticker,
-          type,
+          side,
           status,
           price,
           quantity,
           breakoutRef,
         }: {
           ticker: string;
-          type: TRADE_SIDE;
+          side: TRADE_SIDE;
           status: TRADE_STATUS;
           price: number;
           quantity: number;
@@ -50,7 +50,7 @@ export default async function handler(
         responseData.status = "OK";
         await postTrade({
           ticker,
-          type,
+          side,
           status,
           price,
           quantity,

--- a/src/pages/api/broker/orders/index.ts
+++ b/src/pages/api/broker/orders/index.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { ResponseDataType } from "../../../../db/ResponseDataMeta";
 import { postTrade } from "../../../../db/tradesEntity";
-import { TRADE_STATUS, TRADE_TYPE } from "../../../../db/tradesMeta";
+import { TRADE_STATUS, TRADE_SIDE } from "../../../../db/tradesMeta";
 import * as alpacaService from "../../../../services/alpacaService";
 
 interface ExtendedResponseDataType extends ResponseDataType {
@@ -40,7 +40,7 @@ export default async function handler(
           breakoutRef,
         }: {
           ticker: string;
-          type: TRADE_TYPE;
+          type: TRADE_SIDE;
           status: TRADE_STATUS;
           price: number;
           quantity: number;

--- a/src/pages/api/broker/orders/index.ts
+++ b/src/pages/api/broker/orders/index.ts
@@ -65,7 +65,7 @@ export default async function handler(
 
         // const created_at = Date.parse(result.created_at).toString(); // result.created_at: '2022-12-05T11:02:02.058370387Z'
         // await alpacaService
-        //   .postNewBuyOrder(ticker, type, price, quantity)
+        //   .postNewBuyOrder(ticker, price, quantity)
         //   .then(async (result) => {
         //     const alpacaOrderId = result.id;
         //     const created_at = Date.parse(result.created_at).toString(); // result.created_at: '2022-12-05T11:02:02.058370387Z'
@@ -86,7 +86,6 @@ export default async function handler(
         //     responseData.status = "NOK";
         //     responseData.message = e.message;
         //   });
-
         break;
       default:
         throw new Error(`Unsupported method: ${method as string}`);

--- a/src/store/tradesStore.ts
+++ b/src/store/tradesStore.ts
@@ -3,7 +3,7 @@ import { TRADE_STATUS, TRADE_SIDE } from "../db/tradesMeta";
 
 export type TradesStoreType = {
   ticker: string;
-  type: TRADE_SIDE;
+  side: TRADE_SIDE;
   status: TRADE_STATUS;
   breakoutRef: string;
 };

--- a/src/store/tradesStore.ts
+++ b/src/store/tradesStore.ts
@@ -1,9 +1,9 @@
 import create from "zustand";
-import { TRADE_STATUS, TRADE_TYPE } from "../db/tradesMeta";
+import { TRADE_STATUS, TRADE_SIDE } from "../db/tradesMeta";
 
 export type TradesStoreType = {
   ticker: string;
-  type: TRADE_TYPE;
+  type: TRADE_SIDE;
   status: TRADE_STATUS;
   breakoutRef: string;
 };


### PR DESCRIPTION
This causes no changes in DB. However, maybe it would be reasonable to change the field "_type_" in DB to "_side_". To prevent confusion. In DB, our field _"type"_ has values that correspond to the alpaca API's field _"side"_. 

@ Alpaca:
 - valid values for _side_ are "buy" or "sell" 
- valid valued for _type_ is: market, limit, stop, stop_limit, trailing_stop

@ our DB:
- _type_ is set to "buy" or "sell"