### PR TITLE
Feature/next breakout ver 2

### DIFF
--- a/src/components/atoms/buttons/NavButton.tsx
+++ b/src/components/atoms/buttons/NavButton.tsx
@@ -8,12 +8,13 @@ interface Props {
   href: string;
   goBack?: boolean;
   className?: string;
+  disabled?: boolean;
 }
 
 const StyledButton = styled(Button)`
   width: fit-content;
 `;
-const NavButton = ({ children, href, goBack, className }: Props) => {
+const NavButton = ({ children, href, goBack, className, disabled }: Props) => {
   const router = useRouter();
 
   if (goBack) {
@@ -22,6 +23,13 @@ const NavButton = ({ children, href, goBack, className }: Props) => {
         <StyledButton>{children}</StyledButton>
       </span>
     );
+  }
+  if (disabled) {
+    return (
+      <span className={className}>
+        <StyledButton disabled>{children}</StyledButton>
+      </span>
+    )
   }
   return (
     <Link href={href}>

--- a/src/components/molecules/OrderDetailsWrapper.tsx
+++ b/src/components/molecules/OrderDetailsWrapper.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import { getDateTime } from "../../lib/helpers";
 import { INDICATOR } from "../../lib/priceHandler";
-import { MinimalOrderType } from "../../pages/prepare-order/[ticker]";
+import { MinimalOrderType } from "../../pages/daily-runs/[date]/[time]/prepare-order/[ticker]";
 import {
   AlpacaOrderType,
   SUMMED_ORDER_STATUS,

--- a/src/components/molecules/PlaceOrderButton.tsx
+++ b/src/components/molecules/PlaceOrderButton.tsx
@@ -40,6 +40,10 @@ const PlaceOrderButton = ({
     state.upsertTrade,
   ]);
 
+  useEffect(() => {
+    setBuyPrice(entryPrice);
+  }, [entryPrice]);
+
   useInterval(() => {
     setInterval(ONE_MINUTE_IN_MS);
     void backendService.getTradesDataByTicker(ticker).then((data) => {

--- a/src/components/organisms/BreakoutsList.tsx
+++ b/src/components/organisms/BreakoutsList.tsx
@@ -27,6 +27,8 @@ const StyledImage = styled.img`
 interface Props {
   data: BreakoutStoreType[];
   disableBuy?: boolean;
+  date: string;
+  time: string;
 }
 interface ModalProps {
   breakoutRef: string;
@@ -37,7 +39,7 @@ interface ModalProps {
   symbol: string;
 }
 
-const BreakoutsList = ({ data, disableBuy }: Props) => {
+const BreakoutsList = ({ data, disableBuy, date, time }: Props) => {
   const TheBreakoutModal = memo(
     ({
       isOpen,
@@ -134,7 +136,7 @@ const BreakoutsList = ({ data, disableBuy }: Props) => {
         <Operations>
           {!disableBuy && (
             <>
-              <NavButton href={`/prepare-order/${item.tickerRef}`}>
+              <NavButton href={`/daily-runs/${date}/${time}/prepare-order/${item.tickerRef}`}>
                 Prepare order
               </NavButton>
               <CancelOrderButton ticker={item.tickerRef} />

--- a/src/pages/daily-runs/[date]/[time]/index.tsx
+++ b/src/pages/daily-runs/[date]/[time]/index.tsx
@@ -3,27 +3,27 @@ import type { NextPage } from "next";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import fetch from "node-fetch";
-import { handleResult } from "../../../util";
-import { DailyRunDataType } from "../../../db/dailyRunsMeta";
+import { handleResult } from "../../../../util";
+import { DailyRunDataType } from "../../../../db/dailyRunsMeta";
 import {
   BreakoutWithRatingDataType,
   ExistingBreakoutDataType,
-} from "../../../db/breakoutsEntity";
-import BreakoutsList from "../../../components/organisms/BreakoutsList";
-import { handleLimitPrice } from "../../../util/handleLimitPrice";
-import { ErrorDataParsedType } from "../../../db/errorsMeta";
+} from "../../../../db/breakoutsEntity";
+import BreakoutsList from "../../../../components/organisms/BreakoutsList";
+import { handleLimitPrice } from "../../../../util/handleLimitPrice";
+import { ErrorDataParsedType } from "../../../../db/errorsMeta";
 import {
   formatDateString,
   formatTimestampToUtc,
   formatTimeString,
-} from "../../../util/handleFormatDateString";
-import { isToday } from "../../../lib/helpers";
-import NavButton from "../../../components/atoms/buttons/NavButton";
-import PageContainer from "../../../components/atoms/PageContainer";
-import { getServerSidePropsAllPages } from "../../../lib/getServerSidePropsAllPages";
-import { useBreakoutsStore } from "../../../store/breakoutsStore";
-import Button from "../../../components/atoms/buttons/Button";
-import { ButtonsContainer } from "../../../components/atoms/ButtonsContainer";
+} from "../../../../util/handleFormatDateString";
+import { isToday } from "../../../../lib/helpers";
+import NavButton from "../../../../components/atoms/buttons/NavButton";
+import PageContainer from "../../../../components/atoms/PageContainer";
+import { getServerSidePropsAllPages } from "../../../../lib/getServerSidePropsAllPages";
+import { useBreakoutsStore } from "../../../../store/breakoutsStore";
+import Button from "../../../../components/atoms/buttons/Button";
+import { ButtonsContainer } from "../../../../components/atoms/ButtonsContainer";
 
 // eslint-disable-next-line no-unused-vars
 enum STATUS {
@@ -162,6 +162,8 @@ const DailyRun: NextPage = () => {
       )}
       <BreakoutsList
         data={breakoutsData}
+        date={date as string}
+        time={time}
         disableBuy={!isToday(formatDateString(dateString))}
       />
     </PageContainer>


### PR DESCRIPTION
Matter of discussion:
I moved the prepare order section to be inside a daily run context. To me it seems like a prepare order view is tied to a daily run and therefor it makes sense. So 
```
/prepare-order/{ticker} -> /daily-runs/{date}/{time}/prepare-order/{ticker}
```
This made it possible in a not too complicated way to move between prepare order tickers
```
/daily-runs/20230107/050036/prepare-order/NUVL
->
daily-runs/20230107/050036/prepare-order/PXS
```
but also to go back to the list of breakouts
```
/daily-runs/20230107/050036/prepare-order/NUVL
->
daily-runs/20230107/050036/
```

So when pushing a new ticker in the browser history we previously lost the daily run context. Now we have it in the url.

I also added a useEffect to load all breakouts from the api. This makes it possible to refresh the prepare order page for a ticker. Before the store would be empty after a refresh naturally