### PR TITLE
Remove extra margin and therefor horizontal scrolling

### DIFF
--- a/src/components/atoms/buttons/Button.tsx
+++ b/src/components/atoms/buttons/Button.tsx
@@ -18,7 +18,7 @@ const EnabledDiv = styled.div`
 
   ::after {
     content: "";
-    position: absolute;
+    position: inherit;
     z-index: -1;
     width: 100%;
     height: 100%;


### PR DESCRIPTION
It was possible to scroll horizontally due to extra margin next to the login and logout button. This seems to fix it